### PR TITLE
Polish README a little

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Overview
 ----------
 
-Dust3D is fundamentally new 3D modeling software. It lets you create watertight 3D models in seconds. Use it to speed up character modeling for games, 3D printing, and so on.
+Dust3D is brand new 3D modeling software. It lets you create watertight 3D models in seconds. Use it to speed up character modeling for games, 3D printing, and so on.
 
 
 <a href="https://blogs.dust3d.org/2019/07/18/dust3d-awarded-epic-megagrants/"><img width="128" height="128" src="https://dust3d.org/images/Epic_MegaGrants_Recipient_logo.png" /></a>  

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Overview
 
 Dust3D is fundamentally new 3D modeling software. It lets you create watertight 3D models in seconds. Use it to speed up character modeling for games, 3D printing, and so on.
 
+
 <a href="https://blogs.dust3d.org/2019/07/18/dust3d-awarded-epic-megagrants/"><img width="128" height="128" src="https://dust3d.org/images/Epic_MegaGrants_Recipient_logo.png" /></a>  
 
 - [Download Dust3D](https://docs.dust3d.org/en/latest/install.html)  
@@ -39,8 +40,11 @@ chmod a+x ./dust3d-1.0.0-rc.6.AppImage
 ./dust3d-1.0.0-rc.6.AppImage
 ```
 
+Examples
+-------------
 
 <a href="https://github.com/Dust3D-Modeling/10minuteseveryday/tree/master/jeremyhu2016/giraffe"><image src="https://raw.githubusercontent.com/Dust3D-Modeling/10minuteseveryday/master/jeremyhu2016/giraffe/giraffe.png" width="358" height="216"></a> <a href="https://github.com/Dust3D-Modeling/10minuteseveryday/tree/master/jeremyhu2016/honda-monkey"><image src="https://raw.githubusercontent.com/Dust3D-Modeling/10minuteseveryday/master/jeremyhu2016/honda-monkey/honda-monkey.png" width="358" height="216"></a>
+ 
 
 External Links
 -------------
@@ -56,6 +60,7 @@ External Links
 External Media
 -------------
 [Dust3D -- Free Open Source 3D Modelling Application](https://www.youtube.com/watch?v=YBnEQk_5D70)
+
 
 <a href="https://www.youtube.com/watch?v=YBnEQk_5D70" target="_blank"><image src="https://raw.githubusercontent.com/huxingyi/dust3d/master/docs/images/dust3d-free-open-source-3d-modelling-application-video-thumbnail.png" width="480" height="270"></a>
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Dust3D is fundamentally new 3D modeling software. It lets you create watertight 
 - [Quick Start](https://docs.dust3d.org)  
 - __[Join Mailing List to get Updated](https://www.freelists.org/list/dust3d)__  
 
+Examples
+-------------
+
+<a href="https://github.com/Dust3D-Modeling/10minuteseveryday/tree/master/jeremyhu2016/giraffe"><image src="https://raw.githubusercontent.com/Dust3D-Modeling/10minuteseveryday/master/jeremyhu2016/giraffe/giraffe.png" width="358" height="216"></a> <a href="https://github.com/Dust3D-Modeling/10minuteseveryday/tree/master/jeremyhu2016/honda-monkey"><image src="https://raw.githubusercontent.com/Dust3D-Modeling/10minuteseveryday/master/jeremyhu2016/honda-monkey/honda-monkey.png" width="358" height="216"></a>
+
+
 Installation
 ----------------------
 
@@ -39,12 +45,6 @@ We provide a `.AppImage` file in the [releases tab](https://github.com/huxingyi/
 chmod a+x ./dust3d-1.0.0-rc.6.AppImage
 ./dust3d-1.0.0-rc.6.AppImage
 ```
-
-Examples
--------------
-
-<a href="https://github.com/Dust3D-Modeling/10minuteseveryday/tree/master/jeremyhu2016/giraffe"><image src="https://raw.githubusercontent.com/Dust3D-Modeling/10minuteseveryday/master/jeremyhu2016/giraffe/giraffe.png" width="358" height="216"></a> <a href="https://github.com/Dust3D-Modeling/10minuteseveryday/tree/master/jeremyhu2016/honda-monkey"><image src="https://raw.githubusercontent.com/Dust3D-Modeling/10minuteseveryday/master/jeremyhu2016/honda-monkey/honda-monkey.png" width="358" height="216"></a>
- 
 
 External Links
 -------------

--- a/README.md
+++ b/README.md
@@ -5,13 +5,40 @@
 Overview
 ----------
 
-Dust3D is a brand new 3D modeling software. It helps you create a 3D watertight model in seconds. Use it to speed up your character modeling in game making, 3D printing, and so on.  
+Dust3D is fundamentally new 3D modeling software. It helps you create a 3D watertight model in seconds. Use it to speed up your character modeling in game making, 3D printing, and so on.
 
 <a href="https://blogs.dust3d.org/2019/07/18/dust3d-awarded-epic-megagrants/"><img width="128" height="128" src="https://dust3d.org/images/Epic_MegaGrants_Recipient_logo.png" /></a>  
 
-- [Download Dust3D Software](https://docs.dust3d.org/en/latest/install.html)  
+- [Download Dust3D](https://docs.dust3d.org/en/latest/install.html)  
 - [Quick Start](https://docs.dust3d.org)  
 - __[Join Mailing List to get Updated](https://www.freelists.org/list/dust3d)__  
+
+Installation
+----------------------
+
+Dust3D is available for Windows, macOS, and Linux.
+
+You can get the <a href="https://github.com/huxingyi/dust3d/releases">latest version</a> in the Releases tab of this GitHub repo. If you're feeling adventurous, you can also <a href="https://docs.dust3d.org/en/latest/builds.html">build from source</a>.
+
+### Windows
+
+[Download the .exe](https://github.com/huxingyi/dust3d/releases) – no installation necessary.
+
+### macOS
+
+On macOS, you can download the `.dmg` file or with homebrew:
+```sh
+brew cask install dust3d
+```
+
+### Linux
+
+We provide a `.AppImage` file in the [releases tab](https://github.com/huxingyi/dust3d/releases):
+```sh
+chmod a+x ./dust3d-1.0.0-rc.6.AppImage
+./dust3d-1.0.0-rc.6.AppImage
+```
+
 
 Screenshots
 ----------------------

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Dust3D is fundamentally new 3D modeling software. It lets you create watertight 
 Installation
 ----------------------
 
-Dust3D is available for Windows, macOS, and Linux.
+Dust3D is available for Windows, macOS, and Linux under the [MIT license](https://github.com/huxingyi/dust3d/blob/master/LICENSE). Its completely free and [open source](#license)
 
-You can get the <a href="https://github.com/huxingyi/dust3d/releases">latest version</a> in the Releases tab of this GitHub repository. If you're feeling adventurous, you can also <a href="https://docs.dust3d.org/en/latest/builds.html">build from source</a>.
+You can get the <strong><a href="https://github.com/huxingyi/dust3d/releases">latest version</a></strong> in the Releases tab of this GitHub repository. If you're feeling adventurous, you can also <a href="https://docs.dust3d.org/en/latest/builds.html">build from source</a>.
 
 ### Windows
 
@@ -40,8 +40,6 @@ chmod a+x ./dust3d-1.0.0-rc.6.AppImage
 ```
 
 
-Screenshots
-----------------------
 <a href="https://github.com/Dust3D-Modeling/10minuteseveryday/tree/master/jeremyhu2016/giraffe"><image src="https://raw.githubusercontent.com/Dust3D-Modeling/10minuteseveryday/master/jeremyhu2016/giraffe/giraffe.png" width="358" height="216"></a> <a href="https://github.com/Dust3D-Modeling/10minuteseveryday/tree/master/jeremyhu2016/honda-monkey"><image src="https://raw.githubusercontent.com/Dust3D-Modeling/10minuteseveryday/master/jeremyhu2016/honda-monkey/honda-monkey.png" width="358" height="216"></a>
 
 External Links
@@ -63,12 +61,15 @@ External Media
 
 Contributing
 ---------------
-Any contributions are welcome, including fix bug, correct typo, test functionality, propose new features, make post to introduce and let more people know Dust3D. If you have done any of these, and cannot find your name in CONTRIBUTORS, please feel free to make a pull request to add your name, or email me.
-If you have done programming code changes, including the example code listed in the docs folder, please don’t forget to add your name to AUTHORS in your pull request.
+Any contributions are welcome including bugfixes, fixing typos, adding tests, proposing new features, and letting more people know about Dust3D.
+
+If you write or post about Dust3D online, please add your name in CONTRIBUTORS.
+
+If you've submitted any PRs with code changes, including the example code listed in the docs folder, please don’t forget to add your name to AUTHORS in your pull request.
 
 License
 -----------
-Dust3D software source code use MIT license, however, some of the third party libraries are not MIT license compatible, such as CGAL. Which means you can use the released Dust3D software freely no matter for personal or for commercial purpose, and you can integrate the source code of Dust3D to your project as MIT licensed, but with the third party libraries on the specified license respectively.
+Dust3D's source code is available under the MIT license, however, some third party libraries we use are not MIT license compatible, such as CGAL. You can use the released Dust3D software freely no matter for personal or for commercial purpose, and you can integrate the source code of Dust3D to your project as MIT licensed, but with the third party libraries on the specified license respectively.
 
 Acknowledgements
 -------------------

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-<a href="https://dust3d.org" target="_blank"><image src="https://dust3d.org/images/dust3d-logo-wide.png" width="94" height="30"></a>
+<a href="https://dust3d.org" target="_blank"><image src="https://dust3d.org/images/dust3d-logo-wide.png" width="320" height="102"></a>
 
 [![appveyor status](https://ci.appveyor.com/api/projects/status/github/huxingyi/dust3d?branch=master&svg=true)](https://ci.appveyor.com/project/huxingyi/dust3d) [![travis status](https://travis-ci.org/huxingyi/dust3d.svg?branch=master)](https://travis-ci.org/huxingyi/dust3d) [![readthedocs status](https://readthedocs.org/projects/dust3d/badge/?version=latest)](https://docs.dust3d.org/en/latest/?badge=latest) [![](https://img.shields.io/twitter/follow/jeremyhu2016.svg?label=%20%40follow&style=social)](https://twitter.com/jeremyhu2016) [![](https://img.shields.io/badge/mailing%20list%20-join-blue.svg)](https://www.freelists.org/list/dust3d) [![](https://img.shields.io/discourse/https/dust3d.discourse.group/status.svg)](https://dust3d.discourse.group/) [![](https://img.shields.io/github/downloads/huxingyi/dust3d/total.svg)](https://docs.dust3d.org/en/latest/install.html)
 
 Overview
 ----------
 
-Dust3D is fundamentally new 3D modeling software. It helps you create a 3D watertight model in seconds. Use it to speed up your character modeling in game making, 3D printing, and so on.
+Dust3D is fundamentally new 3D modeling software. It lets you create watertight 3D models in seconds. Use it to speed up character modeling for games, 3D printing, and so on.
 
 <a href="https://blogs.dust3d.org/2019/07/18/dust3d-awarded-epic-megagrants/"><img width="128" height="128" src="https://dust3d.org/images/Epic_MegaGrants_Recipient_logo.png" /></a>  
 
@@ -18,7 +18,7 @@ Installation
 
 Dust3D is available for Windows, macOS, and Linux.
 
-You can get the <a href="https://github.com/huxingyi/dust3d/releases">latest version</a> in the Releases tab of this GitHub repo. If you're feeling adventurous, you can also <a href="https://docs.dust3d.org/en/latest/builds.html">build from source</a>.
+You can get the <a href="https://github.com/huxingyi/dust3d/releases">latest version</a> in the Releases tab of this GitHub repository. If you're feeling adventurous, you can also <a href="https://docs.dust3d.org/en/latest/builds.html">build from source</a>.
 
 ### Windows
 
@@ -42,10 +42,7 @@ chmod a+x ./dust3d-1.0.0-rc.6.AppImage
 
 Screenshots
 ----------------------
-<a href="https://github.com/Dust3D-Modeling/10minuteseveryday/tree/master/jeremyhu2016/giraffe"><image src="https://raw.githubusercontent.com/Dust3D-Modeling/10minuteseveryday/master/jeremyhu2016/giraffe/giraffe.png" width="358" height="216"></a>
-
-
-<a href="https://github.com/Dust3D-Modeling/10minuteseveryday/tree/master/jeremyhu2016/honda-monkey"><image src="https://raw.githubusercontent.com/Dust3D-Modeling/10minuteseveryday/master/jeremyhu2016/honda-monkey/honda-monkey.png" width="358" height="216"></a>
+<a href="https://github.com/Dust3D-Modeling/10minuteseveryday/tree/master/jeremyhu2016/giraffe"><image src="https://raw.githubusercontent.com/Dust3D-Modeling/10minuteseveryday/master/jeremyhu2016/giraffe/giraffe.png" width="358" height="216"></a> <a href="https://github.com/Dust3D-Modeling/10minuteseveryday/tree/master/jeremyhu2016/honda-monkey"><image src="https://raw.githubusercontent.com/Dust3D-Modeling/10minuteseveryday/master/jeremyhu2016/honda-monkey/honda-monkey.png" width="358" height="216"></a>
 
 External Links
 -------------


### PR DESCRIPTION
I added an installation section to the `README` file so its a little easier for people with macOS to copy-paste. 

Ideally, it would include direct links to download for Linux/Windows but I'm not sure if you have the `README` setup behind a build script to set those and I'm hesitant to add more work before shipping a new release.

I also changed this sentence:
> Dust3D is a brand new 3D modeling software.

I think calling it "fundamentally new" sounds stronger than "brand new" because it emphasizes that its not just a new UI on top of an old pattern (Blender, maya, etc) – its an entirely new approach to 3D modeling.

> Dust3D is fundamentally new 3D modeling software.

If you don't agree with the changes no worries at all about closing

Other suggestions:
- Include an installer for Windows so that people can open it easier from the start menu
- Maybe the example section should have like 10 of the best examples from https://github.com/Dust3D-Modeling/10minuteseveryday? And include how long it took to make them. I think its good to include lots of screenshots and have a GitHub README with lots of content


