### PR TITLE
Added rescale on shift+mouse move

### DIFF
--- a/src/skeletongraphicswidget.cpp
+++ b/src/skeletongraphicswidget.cpp
@@ -53,7 +53,8 @@ SkeletonGraphicsWidget::SkeletonGraphicsWidget(const SkeletonDocument *document)
     m_mainProfileOnly(false),
     m_turnaroundOpacity(0.25),
     m_rotated(false),
-    m_backgroundImage(nullptr)
+    m_backgroundImage(nullptr),
+    m_scaleStarted(false)
 {
     setRenderHint(QPainter::Antialiasing, false);
     setBackgroundBrush(QBrush(QWidget::palette().color(QWidget::backgroundRole()), Qt::SolidPattern));
@@ -912,7 +913,7 @@ bool SkeletonGraphicsWidget::mouseMove(QMouseEvent *event)
     
     if (SkeletonDocumentEditMode::Select == m_document->editMode) {
         if (QGuiApplication::queryKeyboardModifiers().testFlag(Qt::ShiftModifier)) {
-            if(m_scaleStarted) {
+            if (m_scaleStarted) {
                 QPoint currentPos = event->globalPos();
                 QPoint deltaPos = currentPos - m_lastScalePos;
                 m_lastScalePos = currentPos;
@@ -923,12 +924,10 @@ bool SkeletonGraphicsWidget::mouseMove(QMouseEvent *event)
                     } else {
                         zoomSelected(delta);
                     }
-                    emit groupOperationAdded();
                     return true;
                 } else if (m_hoveredNodeItem) {
                     float unifiedDelta = sceneRadiusToUnified(delta);
                     emit scaleNodeByAddRadius(m_hoveredNodeItem->id(), unifiedDelta);
-                    emit groupOperationAdded();
                     return true;
                 }
             } else {
@@ -936,7 +935,10 @@ bool SkeletonGraphicsWidget::mouseMove(QMouseEvent *event)
                 m_scaleStarted = true;
             }
         } else {
-            m_scaleStarted = false;
+            if (m_scaleStarted) {
+                m_scaleStarted = false;
+                emit groupOperationAdded();
+            }   
         }
     }
     

--- a/src/skeletongraphicswidget.cpp
+++ b/src/skeletongraphicswidget.cpp
@@ -910,6 +910,36 @@ bool SkeletonGraphicsWidget::mouseMove(QMouseEvent *event)
         }
     }
     
+    if (SkeletonDocumentEditMode::Select == m_document->editMode) {
+        if (QGuiApplication::queryKeyboardModifiers().testFlag(Qt::ShiftModifier)) {
+            if(m_scaleStarted) {
+                QPoint currentPos = event->globalPos();
+                QPoint deltaPos = currentPos - m_lastScalePos;
+                m_lastScalePos = currentPos;
+                float delta = deltaPos.x() * 0.05;
+                if (!m_rangeSelectionSet.empty()) {
+                    if (QGuiApplication::queryKeyboardModifiers().testFlag(Qt::ControlModifier)) {
+                        scaleSelected(delta);
+                    } else {
+                        zoomSelected(delta);
+                    }
+                    emit groupOperationAdded();
+                    return true;
+                } else if (m_hoveredNodeItem) {
+                    float unifiedDelta = sceneRadiusToUnified(delta);
+                    emit scaleNodeByAddRadius(m_hoveredNodeItem->id(), unifiedDelta);
+                    emit groupOperationAdded();
+                    return true;
+                }
+            } else {
+                m_lastScalePos = event->globalPos();
+                m_scaleStarted = true;
+            }
+        } else {
+            m_scaleStarted = false;
+        }
+    }
+    
     if (SkeletonDocumentEditMode::Select == m_document->editMode ||
             SkeletonDocumentEditMode::Add == m_document->editMode) {
         

--- a/src/skeletongraphicswidget.h
+++ b/src/skeletongraphicswidget.h
@@ -724,6 +724,8 @@ private:
     QUuid m_lastCheckedPart;
     std::set<QUuid> m_deferredRemoveNodeIds;
     std::set<QUuid> m_deferredRemoveEdgeIds;
+    QPoint m_lastScalePos;
+    bool m_scaleStarted;
 };
 
 class SkeletonGraphicsContainerWidget : public QWidget


### PR DESCRIPTION
Quick and dirty implementation, when holding down the shift key in edit mode and moving the mouse left/right it will scale the radius of the selected nodes.