### PR TITLE
Model rotation improvement

### DIFF
--- a/application/sources/model_widget.cc
+++ b/application/sources/model_widget.cc
@@ -320,6 +320,7 @@ bool ModelWidget::inputMousePressEventFromOtherWidget(QMouseEvent *event, bool n
             m_moveStartPos = mapToParent(convertInputPosFromOtherWidget(event));
             m_moveStartGeometry = geometry();
             m_moveStarted = true;
+            m_directionOnMoveStart = abs(m_xRot) > 180 * 8 ? -1 : 1;
         }
         return true;
     }
@@ -389,7 +390,7 @@ bool ModelWidget::inputMouseMoveEventFromOtherWidget(QMouseEvent *event)
             }
         } else {
             setXRotation(m_xRot + 8 * dy);
-            setYRotation(m_yRot + 8 * dx);
+            setYRotation(m_yRot + 8 * dx * m_directionOnMoveStart);
         }
     }
     m_lastPos = pos;

--- a/application/sources/model_widget.h
+++ b/application/sources/model_widget.h
@@ -92,6 +92,7 @@ private:
     int m_xRot = m_defaultXRotation;
     int m_yRot = m_defaultYRotation;
     int m_zRot = m_defaultZRotation;
+    int m_directionOnMoveStart = 0;
     ModelShaderProgram *m_program = nullptr;
     bool m_moveStarted = false;
     bool m_moveEnabled = true;


### PR DESCRIPTION
The way rotation currently works on the vertical axis is very unintuitive. This is a fix to make the way a model rotates behave similarly to Blender and other 3D modelers.

If the object's horizontal axis rotation is greater than +-180 degrees we invert the rotation direction. Since this transformation would not be continuous, we keep the rotation direction for the duration of the mouse movement.