### PR TITLE
Fix mirror color

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -104,7 +104,7 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
-ReflowComments:  true
+ReflowComments:  false
 SortIncludes:    true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false

--- a/application/sources/document.cc
+++ b/application/sources/document.cc
@@ -2240,6 +2240,7 @@ void Document::meshReady()
     ModelMesh* resultMesh = m_meshGenerator->takeResultMesh();
     m_wireframeMesh.reset(m_meshGenerator->takeWireframeMesh());
     dust3d::Object* object = m_meshGenerator->takeObject();
+    dust3d::Snapshot* snapshot = m_meshGenerator->takeSnapshot();
     bool isSuccessful = m_meshGenerator->isSuccessful();
 
     std::unique_ptr<std::map<dust3d::Uuid, std::unique_ptr<ModelMesh>>> componentPreviewMeshes;
@@ -2265,8 +2266,8 @@ void Document::meshReady()
 
     m_isMeshGenerationSucceed = isSuccessful;
 
-    delete m_currentObject;
-    m_currentObject = object;
+    m_currentObject.reset(object);
+    m_currentSnapshot.reset(snapshot);
 
     if (nullptr == m_resultMesh) {
         qDebug() << "Result mesh is null";
@@ -2363,7 +2364,7 @@ void Document::generateTexture()
 
     m_isTextureObsolete = false;
 
-    if (nullptr == m_currentObject)
+    if (nullptr == m_currentObject || nullptr == m_currentSnapshot)
         return;
 
     qDebug() << "UV mapping generating..";
@@ -2371,8 +2372,7 @@ void Document::generateTexture()
 
     auto object = std::make_unique<dust3d::Object>(*m_currentObject);
 
-    auto snapshot = std::make_unique<dust3d::Snapshot>();
-    toSnapshot(snapshot.get());
+    auto snapshot = std::make_unique<dust3d::Snapshot>(*m_currentSnapshot);
 
     QThread* thread = new QThread;
     m_textureGenerator = new UvMapGenerator(std::move(object), std::move(snapshot));

--- a/application/sources/document.h
+++ b/application/sources/document.h
@@ -496,7 +496,8 @@ private:
     std::unique_ptr<MonochromeMesh> m_wireframeMesh;
     bool m_isMeshGenerationSucceed = true;
     int m_batchChangeRefCount = 0;
-    dust3d::Object* m_currentObject = nullptr;
+    std::unique_ptr<dust3d::Object> m_currentObject;
+    std::unique_ptr<dust3d::Snapshot> m_currentSnapshot;
     bool m_isTextureObsolete = false;
     UvMapGenerator* m_textureGenerator = nullptr;
     std::unique_ptr<dust3d::Object> m_uvMappedObject = std::make_unique<dust3d::Object>();

--- a/dust3d/mesh/mesh_generator.cc
+++ b/dust3d/mesh/mesh_generator.cc
@@ -1018,20 +1018,6 @@ std::unique_ptr<MeshState> MeshGenerator::combineComponentChildGroupMesh(const s
     return combineMultipleMeshes(std::move(multipleMeshes));
 }
 
-void MeshGenerator::makeXmirror(const std::vector<Vector3>& sourceVertices, const std::vector<std::vector<size_t>>& sourceFaces,
-    std::vector<Vector3>* destVertices, std::vector<std::vector<size_t>>* destFaces)
-{
-    for (const auto& mirrorFrom : sourceVertices) {
-        destVertices->push_back(Vector3(-mirrorFrom.x(), mirrorFrom.y(), mirrorFrom.z()));
-    }
-    std::vector<std::vector<size_t>> newFaces;
-    for (const auto& mirrorFrom : sourceFaces) {
-        auto newFace = mirrorFrom;
-        std::reverse(newFace.begin(), newFace.end());
-        destFaces->push_back(newFace);
-    }
-}
-
 void MeshGenerator::collectSharedQuadEdges(const std::vector<Vector3>& vertices, const std::vector<std::vector<size_t>>& faces,
     std::set<std::pair<PositionKey, PositionKey>>* sharedQuadEdges)
 {

--- a/dust3d/mesh/mesh_generator.cc
+++ b/dust3d/mesh/mesh_generator.cc
@@ -78,6 +78,13 @@ Object* MeshGenerator::takeObject()
     return object;
 }
 
+Snapshot* MeshGenerator::takeSnapshot()
+{
+    Snapshot* snapshot = m_snapshot;
+    m_snapshot = nullptr;
+    return snapshot;
+}
+
 void MeshGenerator::chamferFace(std::vector<Vector2>* face)
 {
     auto oldFace = *face;

--- a/dust3d/mesh/mesh_generator.h
+++ b/dust3d/mesh/mesh_generator.h
@@ -112,6 +112,7 @@ public:
     const std::set<Uuid>& generatedPreviewComponentIds();
     const std::map<Uuid, ComponentPreview>& generatedComponentPreviews();
     Object* takeObject();
+    Snapshot* takeSnapshot();
     virtual void generate();
     void setGeneratedCacheContext(GeneratedCacheContext* cacheContext);
     void setSmoothShadingThresholdAngleDegrees(float degrees);

--- a/dust3d/mesh/mesh_generator.h
+++ b/dust3d/mesh/mesh_generator.h
@@ -154,8 +154,6 @@ private:
         float smoothCutoffDegrees,
         bool* hasError);
     std::unique_ptr<MeshState> combineComponentMesh(const std::string& componentIdString, CombineMode* combineMode);
-    void makeXmirror(const std::vector<Vector3>& sourceVertices, const std::vector<std::vector<size_t>>& sourceFaces,
-        std::vector<Vector3>* destVertices, std::vector<std::vector<size_t>>* destFaces);
     void collectSharedQuadEdges(const std::vector<Vector3>& vertices, const std::vector<std::vector<size_t>>& faces,
         std::set<std::pair<PositionKey, PositionKey>>* sharedQuadEdges);
     const std::map<std::string, std::string>* findComponent(const std::string& componentIdString);


### PR DESCRIPTION
- Fixing mirrored components attributes updated in mesh generator, but not passing to later UV generator. This change update the snapshot used in UV generator
- Ignore comments reflow in clang-format, unless all files will be touched because of copyright comments
- Remove unused mirror code, which is old way of doing mirror: only mirror the meshes. The new way of doing mirror: treat the mirrored components as a separate component with all the attributes copied as the same, just the generated mesh's x-coord mirrored.