### PR TITLE
Fix missing MSVCP140_1.dll

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
           ls "${VCToolsRedistDir}x64"
           ls "${VCToolsRedistDir}x64/Microsoft.VC142.CRT"
           7z a Dust3D-win32-x86_64.zip "${VCToolsRedistDir}x64/Microsoft.VC142.CRT/msvcp140.dll"
+          7z a Dust3D-win32-x86_64.zip "${VCToolsRedistDir}x64/Microsoft.VC142.CRT/msvcp140_1.dll"
           7z a Dust3D-win32-x86_64.zip "${VCToolsRedistDir}x64/Microsoft.VC142.CRT/vcruntime140.dll"
           7z a Dust3D-win32-x86_64.zip "${VCToolsRedistDir}x64/Microsoft.VC142.CRT/vcruntime140_1.dll"
           mkdir ${GITHUB_WORKSPACE}/platforms

--- a/CHANGELOGS
+++ b/CHANGELOGS
@@ -1,3 +1,7 @@
+1.0.0-rc.9 (Jul 27, 2023):
+
+- Fix windows build
+
 1.0.0-rc.8 (Jul 18, 2023):
 
 - Fix color and texture of mirrored parts

--- a/application/application.pro
+++ b/application/application.pro
@@ -3,7 +3,7 @@ QT += core gui opengl widgets svg
 TARGET = dust3d
 TEMPLATE = app
 
-HUMAN_VERSION = "1.0.0-rc.9.preview"
+HUMAN_VERSION = "1.0.0-rc.9"
 VERSION = 1.0.0.39
 
 QMAKE_TARGET_COMPANY = Dust3D


### PR DESCRIPTION
Run `dumpbin /DEPENDENTS qt5core.dll` will get `MSVCP140_1.dll` in the output. This was missed in the past release workflow.