### PR TITLE
Fix missing #include <cstdint> for Ubuntu 24.04 build support

### DIFF
--- a/application/third_party/fbx/src/fbxdocument.h
+++ b/application/third_party/fbx/src/fbxdocument.h
@@ -1,6 +1,7 @@
 #ifndef FBXDOCUMENT_H
 #define FBXDOCUMENT_H
 
+#include <cstdint>
 #include "fbxnode.h"
 
 namespace fbx {

--- a/application/third_party/fbx/src/fbxnode.h
+++ b/application/third_party/fbx/src/fbxnode.h
@@ -1,6 +1,7 @@
 #ifndef FBXNODE_H
 #define FBXNODE_H
 
+#include <cstdint>
 #include "fbxproperty.h"
 
 namespace fbx {

--- a/application/third_party/fbx/src/fbxproperty.h
+++ b/application/third_party/fbx/src/fbxproperty.h
@@ -1,6 +1,7 @@
 #ifndef FBXPROPERTY_H
 #define FBXPROPERTY_H
 
+#include <cstdint>
 #include <memory>
 #include <iostream>
 #include <vector>

--- a/dust3d/base/ds3_file.h
+++ b/dust3d/base/ds3_file.h
@@ -23,6 +23,7 @@
 #ifndef DUST3D_BASE_DS3_FILE_H_
 #define DUST3D_BASE_DS3_FILE_H_
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>

--- a/dust3d/mesh/solid_mesh_boolean_operation.h
+++ b/dust3d/mesh/solid_mesh_boolean_operation.h
@@ -26,6 +26,7 @@
 #include <dust3d/base/position_key.h>
 #include <dust3d/base/vector3.h>
 #include <dust3d/mesh/solid_mesh.h>
+#include <cstdint>
 #include <map>
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
## Summary

Add missing `#include <cstdint>` headers to resolve `uint*_t` type compilation errors on GCC 13+ (Ubuntu 24.04 and newer toolchains).

## Problem

On Ubuntu 24.04 with GCC 13+, the `<cstdint>` header is no longer transitively included by other standard headers. This causes compilation failures due to unresolved `uint8_t`, `uint16_t`, `uint32_t`, and `uint64_t` types.

Related: #169

## Changes

Added `#include <cstdint>` to the following files:

- `application/third_party/fbx/src/fbxdocument.h`
- `application/third_party/fbx/src/fbxnode.h`
- `application/third_party/fbx/src/fbxproperty.h`
- `dust3d/base/ds3_file.h`
- `dust3d/mesh/solid_mesh_boolean_operation.h`

## Testing

Project builds successfully on Ubuntu 24.04 with Qt 5.15.13.