### PR TITLE
refactor(combine_mode): remove unnecessary std::string() wrappers

### DIFF
--- a/dust3d/base/combine_mode.cc
+++ b/dust3d/base/combine_mode.cc
@@ -2,22 +2,22 @@
  *  Copyright (c) 2016-2021 Jeremy HU <jeremy-at-dust3d dot org>. All rights reserved. 
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
 
  *  The above copyright notice and this permission notice shall be included in all
- *  copies or substantial portions of the Software.
+ * copies or substantial portions of the Software.
 
  *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- *  SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
 #include <dust3d/base/combine_mode.h>
@@ -54,13 +54,13 @@ std::string CombineModeToDispName(CombineMode mode)
 {
     switch (mode) {
     case CombineMode::Normal:
-        return std::string("Normal");
+        return "Normal";
     case CombineMode::Inversion:
-        return std::string("Inversion");
+        return "Inversion";
     case CombineMode::Uncombined:
-        return std::string("Uncombined");
+        return "Uncombined";
     default:
-        return std::string("Normal");
+        return "Normal";
     }
 }
 


### PR DESCRIPTION
## Summary

Removes unnecessary `std::string()` wrapper calls in `CombineModeToDispName`.

### Before
```cpp
return std::string("Normal");
```

### After
```cpp
return "Normal";
```

String literals implicitly convert to `std::string` when returned, so the explicit constructors add overhead without benefit.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)