### PR TITLE
Enable high DPI scaling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,26 @@ jobs:
         with:
           name: dust3d-${{ github.ref_name }}-windows-2022.png
           path: dust3d-${{ github.ref_name }}-windows-2022.png
+      - name: Run application and capture Windows 1080p 200% screenshot
+        run: |
+          Set-DisplayResolution -Width 1920 -Height 1080 -Force
+          cd dust3d-${{ github.ref_name }}
+          $env:QT_OPENGL = 'software'
+          $env:QT_SCALE_FACTOR = '2'
+          Start-Process -FilePath .\dust3d.exe
+          Start-Sleep -Seconds 12
+          Add-Type -AssemblyName System.Windows.Forms
+          $bitmap = [System.Drawing.Bitmap]::new([System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Width, [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Height)
+          $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+          $graphics.CopyFromScreen(0, 0, 0, 0, $bitmap.Size)
+          $bitmap.Save("$env:GITHUB_WORKSPACE\dust3d-${{ github.ref_name }}-windows-2022-1080p-200pct.png")
+          Stop-Process -Name dust3d -Force -ErrorAction SilentlyContinue
+        shell: powershell
+      - name: Upload Windows 1080p 200% screenshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: dust3d-${{ github.ref_name }}-windows-2022-1080p-200pct.png
+          path: dust3d-${{ github.ref_name }}-windows-2022-1080p-200pct.png
       - name: Run test models
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - master
     tags:
       - '*'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,11 +109,13 @@ jobs:
           target: 'desktop'
           arch: 'win64_msvc2019_64'
           archives: 'qttools qtsvg qtimageformats qtbase qtmultimedia opengl32sw'
+      - name: Install jom
+        run: choco install jom --yes --no-progress
       - name: Build application
         run: |
           cd $env:GITHUB_WORKSPACE/application
           qmake -spec win32-msvc
-          nmake -f Makefile.Release
+          jom -f Makefile.Release -j $env:NUMBER_OF_PROCESSORS
       - name: Set environment variable
         run: |
           set PATH="%PATH%;C:\Program Files\7-Zip"

--- a/application/sources/main.cc
+++ b/application/sources/main.cc
@@ -31,6 +31,11 @@ static auto checkToSafelyExit = []() {
 
 int main(int argc, char* argv[])
 {
+#if defined(Q_OS_WIN) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
+
 #if !defined(Q_OS_WASM)
     QSurfaceFormat format = QSurfaceFormat::defaultFormat();
     format.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);

--- a/application/sources/main.cc
+++ b/application/sources/main.cc
@@ -31,7 +31,7 @@ static auto checkToSafelyExit = []() {
 
 int main(int argc, char* argv[])
 {
-#if defined(Q_OS_WIN) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif


### PR DESCRIPTION
I fixed the DPI scaling issue, hopefully for good.


Qt 5 high-DPI scaling is enabled via `Qt::AA_EnableHighDpiScaling` to respect the platform display scale. 
High-DPI scaling is enabled by default in Qt 6.

This also adds an extra workflow screenshot at 1080p with `QT_SCALE_FACTOR=2`.

Tested on Windows 11 and Ubuntu 24.04.1

Depends on #193

Fixes #183
Fixes #190

---

Before:

<img width="480" alt="pre-1080p-200pct" src="https://github.com/user-attachments/assets/367aa642-3f9e-46bf-8e6b-1f86ae9b461e" />

After:

<img width="480" alt="post-1080p-200pct" src="https://github.com/user-attachments/assets/b0d9e9a5-ea1f-4134-a4fa-c5a0c2885566" />

---

The workflow does not test OS-level display scaling, since GitHub-hosted Windows runners can’t change DPI scale.